### PR TITLE
fix questions fetch

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -187,12 +187,12 @@ export default function QuestionsPage() {
   useEffect(() => {
     if (searchParams) {
       const subjectIds = searchParams.getAll('subject_ids[]');
-      const shuffle = searchParams.getAll('shuffle');
-      const recentMistakes = searchParams.getAll('recent_mistakes');
-      const flaggedQuestions = searchParams.getAll('flagged_questions');
-      // console.log(subjectIds);
+      const shuffle = searchParams.getAll('shuffle').length != 0 ;
+      const recentMistakes = searchParams.getAll('recent_mistakes').length != 0;
+      const flaggedQuestions = searchParams.getAll('flagged_questions').length !=0;
+      // console.log(recentMistakes);
 
-      if (subjectIds) {
+      if (subjectIds.length != 0) {
         const query = Array.isArray(subjectIds)
           ? subjectIds.map(id => `subject_ids[]=${id}`).join('&')
           : `subject_ids[]=${subjectIds}`;


### PR DESCRIPTION
 ログイン状態にて、各年度の問題が表示されないバグを修正。
→questionsのfilterとrecent_mistakes、flagged_questions、shuffleがそれぞれ目的のものだけfetchするように修正。

api側でrecent_mistakesがちゃんと動作してないことが判明したので、そこも直した。